### PR TITLE
Don't show warning about duplicate load calls on plugins page

### DIFF
--- a/class-debug-bar-localization.php
+++ b/class-debug-bar-localization.php
@@ -286,7 +286,8 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 		 * @param string $type The add-on type to create the table for.
 		 */
 		protected function render_load_textdomain_table( $type ) {
-			$logs = $this->logger->filter_logs_on_type( $type );
+			$logs            = $this->logger->filter_logs_on_type( $type );
+			$is_plugins_page = ( is_admin() && 'plugins' === get_current_screen()->base );
 
 			if ( ! empty( $logs ) && is_array( $logs ) ) {
 				echo '
@@ -309,7 +310,7 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 					echo '
 				<tr';
 
-					if ( true === $has_duplicates ) {
+					if ( true === $has_duplicates && ! $is_plugins_page ) {
 						echo ' class="has-duplicates"';
 					}
 
@@ -330,7 +331,7 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 
 					$this->render_file_list( $domain_object );
 
-					if ( true === $has_duplicates ) {
+					if ( true === $has_duplicates && ! $is_plugins_page ) {
 						echo '
 				</tr>
 				<tr class="has-duplicates">

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,9 @@ Have you read what it says in the beautifully red bar at the top of your plugins
 
 == Changelog ==
 
+= 1.0.1 (2016-xx-xx ) =
+* Don't show warning about duplicate load calls on plugins page as that's caused by core, not by a plugin and the warning could be misleading.
+
 = 1.0 (2016-01-13) =
 * Initial release.
 


### PR DESCRIPTION
…as that's caused by core, not by a plugin and the warning could be misleading.
