### PR TITLE
Improve categorization of the loaded text domains.

### DIFF
--- a/class-debug-bar-localization-log-domain-entry.php
+++ b/class-debug-bar-localization-log-domain-entry.php
@@ -61,8 +61,8 @@ if ( ! class_exists( 'Debug_Bar_Localization_Log_Domain_Entry' ) ) {
 		 */
 		public function add_file( $mo_file ) {
 			// Make sure we have the name of the actual file as used after filtering.
-			$mo_file          = apply_filters( 'load_textdomain_mofile', $mo_file, $this->domain );
-			$this->mo_files[] = new Debug_Bar_Localization_Log_MO_file_Entry( $mo_file );
+			$actual_mo_file   = apply_filters( 'load_textdomain_mofile', $mo_file, $this->domain );
+			$this->mo_files[] = new Debug_Bar_Localization_Log_MO_file_Entry( $actual_mo_file, $mo_file );
 		}
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,7 @@ Have you read what it says in the beautifully red bar at the top of your plugins
 * Don't show warning about duplicate load calls on plugins page as that's caused by core, not by a plugin and the warning could be misleading.
 * Prevent error notices in WP < 4.0.
 * Make loading of text-domain compatible with use of the plugin in the `must-use` plugins directory.
+* [Enhancement] Improve categorization of the loaded text-domains. This mainly applies to text-domains for which the mo_file paths are being filtered.
 * [Bugfix] The plugin loading order functions were inadvertently checking the wrong value and - in single site - install, adding an invalid value to the active plugins list causing incorrect 'plugin deactivated as file not found' notices.
 * General housekeeping
 


### PR DESCRIPTION
If the `$mo_file` path would be filtered, it could interfere with the determination of what type of add-on the request came from.
This PR fixes that by registering both the actual as well as the originally requested mofile and using both to determine the add-on type.
