### PR TITLE
Feature/qa update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,26 +28,28 @@ matrix:
     - php: '7.0'
     # aliased to a recent 7.1.x version
     - php: '7.1'
-    # aliased to a recent hhvm version
-    - php: 'hhvm'
+    # bleeding edge
+    - php: 'nightly'
 
   allow_failures:
-    - php: 'hhvm'
+    - php: 'nightly'
 
-before_script:
-  - export PHPCS_DIR=/tmp/phpcs
-  - export SNIFFS_DIR=/tmp/sniffs
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-  # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
-  # Install PHP Compatibility sniffs.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
-  # Set install path for PHPCS sniffs.
-  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
-  # After CodeSniffer install you should refresh your path.
-  - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+before_install:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export SNIFFS_DIR=/tmp/sniffs
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    # @TODO Change branch back to master once WPCS + PHPCompatibility are compatible with PHPCS 3.x.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    # Install PHP Compatibility sniffs.
+    # @TODO ADJUST PATH FOR Composer PR when merged!
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+    # Set install path for PHPCS sniffs.
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
 
 # Run test script commands.
@@ -55,14 +57,11 @@ before_script:
 script:
     # Search for PHP syntax errors.
     - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    # WordPress Coding Standards.
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://github.com/wimg/phpcompatibility
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -v -n . --standard=./phpcs.xml --extensions=php; fi
+    # Uses a custom ruleset based on WordPress.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --standard=./phpcs.xml --runtime-set ignore_warnings_on_exit 1; fi
 

--- a/class-debug-bar-localization-log-domain-entry.php
+++ b/class-debug-bar-localization-log-domain-entry.php
@@ -34,7 +34,7 @@ if ( ! class_exists( 'Debug_Bar_Localization_Log_Domain_Entry' ) ) {
 		private $domain;
 
 		/**
-		 * Array of \Debug_Bar_Localization_Log_MO_file_Entry objects.
+		 * Array of \Debug_Bar_Localization_Log_MO_File_Entry objects.
 		 * One for each MO file WP tried to load for this text domain.
 		 *
 		 * @var array
@@ -61,8 +61,8 @@ if ( ! class_exists( 'Debug_Bar_Localization_Log_Domain_Entry' ) ) {
 		 */
 		public function add_file( $mo_file ) {
 			// Make sure we have the name of the actual file as used after filtering.
-			$actual_mo_file   = apply_filters( 'load_textdomain_mofile', $mo_file, $this->domain );
-			$this->mo_files[] = new Debug_Bar_Localization_Log_MO_file_Entry( $actual_mo_file, $mo_file );
+			$actual_mo_file   = apply_filters( 'load_textdomain_mofile', $mo_file, $this->domain ); // WPCS: prefix ok.
+			$this->mo_files[] = new Debug_Bar_Localization_Log_MO_File_Entry( $actual_mo_file, $mo_file );
 		}
 
 
@@ -95,11 +95,11 @@ if ( ! class_exists( 'Debug_Bar_Localization_Log_Domain_Entry' ) ) {
 		 */
 		public function get_type() {
 			foreach ( $this->mo_files as $file ) {
-				if ( Debug_Bar_Localization_Log_MO_file_Entry::UNKNOWN_TYPE !== $file->type ) {
+				if ( Debug_Bar_Localization_Log_MO_File_Entry::UNKNOWN_TYPE !== $file->type ) {
 					return $file->type;
 				}
 			}
-			return Debug_Bar_Localization_Log_MO_file_Entry::UNKNOWN_TYPE;
+			return Debug_Bar_Localization_Log_MO_File_Entry::UNKNOWN_TYPE;
 		}
 
 

--- a/class-debug-bar-localization-log-mo-file-entry.php
+++ b/class-debug-bar-localization-log-mo-file-entry.php
@@ -19,12 +19,12 @@ if ( ! function_exists( 'add_action' ) ) {
 	exit();
 }
 
-if ( ! class_exists( 'Debug_Bar_Localization_Log_MO_file_Entry' ) ) {
+if ( ! class_exists( 'Debug_Bar_Localization_Log_MO_File_Entry' ) ) {
 
 	/**
 	 * Class to hold information on an individual MO file.
 	 */
-	class Debug_Bar_Localization_Log_MO_file_Entry {
+	class Debug_Bar_Localization_Log_MO_File_Entry {
 
 		/**
 		 * Keyword used for the 'unknown' add-on type.

--- a/class-debug-bar-localization.php
+++ b/class-debug-bar-localization.php
@@ -269,11 +269,15 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 			$diff = array_diff( $diff, array( 'db-pretty-output' ) );
 
 			if ( ! empty( $diff ) && is_array( $diff ) ) {
+				$kses_allowed = array(
+					'em' => array(),
+				);
+
 				echo '
 			<div id="db-localization-inefficient-load-textdomain">
 				<h3>', esc_html__( 'Potentially inefficient calls', 'debug-bar-localization' ), '</h3>
 				<p>', esc_html__( 'Loading a text domain when it will not be used is inefficient. Lean, or lazy loading is a programming best practice which comes down to only loading files if and when needed.', 'debug-bar-localization' ), '</p>
-				<p>', wp_kses( __( 'The below textdomains <em>were</em> loaded, but were <em>not used</em> in a localization call during this page load.', 'debug-bar-localization' ), array( 'em' => array() ) ), esc_html__( 'This is not always "wrong", but these calls could benefit from a visual code inspection.', 'debug-bar-localization' ), '</p>
+				<p>', wp_kses( __( 'The below textdomains <em>were</em> loaded, but were <em>not used</em> in a localization call during this page load.', 'debug-bar-localization' ), $kses_allowed ), esc_html__( 'This is not always "wrong", but these calls could benefit from a visual code inspection.', 'debug-bar-localization' ), '</p>
 				<ul>';
 				foreach ( $diff as $unused ) {
 					echo '
@@ -333,9 +337,13 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 			</div>';
 
 			} else {
+				$kses_allowed = array(
+					'code' => array(),
+				);
+
 				echo '
 				<hr />
-				<p>', wp_kses( __( 'No text domain load calls made. This should never happen...', 'debug-bar-localization' ), array( 'code' => array() ) ), '</p>';
+				<p>', wp_kses( __( 'No text domain load calls made. This should never happen...', 'debug-bar-localization' ), $kses_allowed ), '</p>';
 			}
 		}
 

--- a/debug-bar-localization.php
+++ b/debug-bar-localization.php
@@ -52,10 +52,14 @@ if ( ! function_exists( 'db_localization_has_parent_plugin' ) ) {
 			deactivate_plugins( DB_LOCALIZATION_BASENAME, false, is_network_admin() );
 
 			// Add to recently active plugins list.
+			$insert = array(
+				DB_LOCALIZATION_BASENAME => time(),
+			);
+
 			if ( ! is_network_admin() ) {
-				update_option( 'recently_activated', ( array( DB_LOCALIZATION_BASENAME => time() ) + (array) get_option( 'recently_activated' ) ) );
+				update_option( 'recently_activated', ( $insert + (array) get_option( 'recently_activated' ) ) );
 			} else {
-				update_site_option( 'recently_activated', ( array( DB_LOCALIZATION_BASENAME => time() ) + (array) get_site_option( 'recently_activated' ) ) );
+				update_site_option( 'recently_activated', ( $insert + (array) get_site_option( 'recently_activated' ) ) );
 			}
 
 			// Prevent trying again on page reload.
@@ -107,8 +111,11 @@ if ( version_compare( $wp_version, '4.0', '>' ) ) {
 			}
 
 			$this_plugin = $value[ DB_LOCALIZATION_BASENAME ];
+			$insert      = array(
+				DB_LOCALIZATION_BASENAME => $this_plugin,
+			);
 			unset( $value[ DB_LOCALIZATION_BASENAME ] );
-			return array_merge( array( DB_LOCALIZATION_BASENAME => $this_plugin ), $value );
+			return array_merge( $this_plugin, $value );
 		}
 	}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,14 @@
 <ruleset name="Debug Bar Localization">
 	<description>The code standard for Debug Bar Localization is WordPress.</description>
 
+	<!-- Show progress & sniff codes. -->
+	<arg value="ps"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
 	<!-- ##### PHP cross-version compatibility ##### -->
 	<config name="testVersion" value="5.2-99.0"/>
 	<rule ref="PHPCompatibility"/>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,12 +16,45 @@
 
 
 	<!-- ##### WordPress sniffs #####-->
-	<rule ref="WordPress">
-		<exclude name="Squiz.WhiteSpace.SuperfluousWhitespace.EmptyLines" />
+	<rule ref="WordPress"/>
+
+
+	<!-- ##### Customizations #####-->
+
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="debug-bar-localization" />
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="Debug_Bar_Localization,db_localization" />
+		</properties>
+	</rule>
+
+	<!-- Verify that no WP functions are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 supported by the Debug Bar extension. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="4.0" />
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="4.0" />
+		</properties>
 	</rule>
 
 
-	<!-- exclude the 'empty' index files from some documentation checks -->
+	<!-- ##### Exlusions #####-->
+
+	<!-- Exclude the 'empty' index files from some documentation checks. -->
 	<rule ref="Squiz.Commenting.FileComment.WrongStyle">
 		<exclude-pattern>*/index.php</exclude-pattern>
 	</rule>


### PR DESCRIPTION
### Update Travis build script
* Include PHP nightly in the build matrix and remove HHVM.
* Use `before_install` rather than `before_script` to better distinguish between failed install or failed build.
* Use the PHPCS `2.9` branch until the external standards are compatible with PHPCS 3.x.
* Use the WPCS `develop` branch to benefit from the latest sniffs.
* Move the standard PHPCS command line arguments to the custom ruleset.
* Show PHPCS warnings, but don't fail the build on it.

### Update the PHPCS ruleset for WPCS 0.12.0
* Remove one exclusion.
* Verify that the correct text domain is being used.
* Verify that everything in the global namespace is prefixed correctly.
* Verify that no WP deprecated functions or classes are used.

### Minor codestyle fixes