### PR TITLE
README: Add "Requires PHP" header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: debugbar, debug-bar, Debug Bar, Localization, Language, Translation, text 
 Requires at least: 4.0
 Tested up to: 4.5
 Stable tag: 1.1
+Requires PHP: 5.2.4
 License: GPLv2
 
 Debug Bar Localization adds a new panel to the Debug Bar which displays information on the locale for your install and the language files loaded.


### PR DESCRIPTION
This new header has been soft launched on August 25th 2017.

Refs:
* https://meta.trac.wordpress.org/ticket/2952
* https://meta.trac.wordpress.org/changeset/5841

https://wordpress.org/plugins/developers/readme-validator/