### PR TITLE
Prevent fatal error in Debug_Bar_Localization::render_last_updated()

### DIFF
--- a/class-debug-bar-localization.php
+++ b/class-debug-bar-localization.php
@@ -484,15 +484,25 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 				echo '-';
 				return;
 			}
-
-			$x_generator   = $GLOBALS['l10n'][ $domain ]->get_header( 'X-Generator' );
-			$revision_date = $GLOBALS['l10n'][ $domain ]->get_header( 'PO-Revision-Date' );
-
+		
+			$translations = $GLOBALS['l10n'][ $domain ];
+		
+			$x_generator = false;
+			$revision_date = false;
+		
+			if ( isset( $translations->headers['X-Generator'] ) ) {
+				$x_generator = $translations->headers['X-Generator'];
+			}
+		
+			if ( isset( $translations->headers['PO-Revision-Date'] ) ) {
+				$revision_date = $translations->headers['PO-Revision-Date'];
+			}
+		
 			if ( false === $revision_date ) {
 				echo '-';
 				return;
 			}
-
+		
 			$generator = __( 'unknown', 'debug-bar-localization' );
 			if ( ! empty( $x_generator ) && is_string( $x_generator ) ) {
 				if ( false !== strpos( $x_generator, 'GlotPress' ) ) {
@@ -503,12 +513,12 @@ if ( ! class_exists( 'Debug_Bar_Localization' ) && class_exists( 'Debug_Bar_Pane
 					$generator = $x_generator;
 				}
 			}
-
+		
 			echo wp_kses_post( sprintf(
 				/* translators: 1: date, 2: translation program name. */
-				__( '%1$s via %2$s', 'debug-bar-localization' ),
+				__( '%s via %s', 'debug-bar-localization' ),
 				substr( $revision_date, 0, 10 ),
-				'<em>' . esc_html( $generator ) . '</em>'
+				'<em>' . $generator . '</em>'
 			) );
 		}
 


### PR DESCRIPTION
This prevents the following fatal error that happens with WordPress 6.5+
```php
Fatal error: Uncaught Error: Call to undefined method WP_Translations::get_header() in /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp-content/plugins/debug-bar-localization/class-debug-bar-localization.php:463 Stack trace: #0 /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp-content/plugins/debug-bar-localization/class-debug-bar-localization.php(385): Debug_Bar_Localization->render_last_updated('default') #1 /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp-content/plugins/debug-bar-localization/class-debug-bar-localization.php(331): Debug_Bar_Localization->render_load_textdomain_table('core') #2 /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp-content/plugins/debug-bar-localization/class-debug-bar-localization.php(181): Debug_Bar_Localization->render_load_textdomain_section() #3 /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp-content/plugins/debug-bar/debug-bar.php(377): Debug_Bar_Localization->render() #4 /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp- in /Users/diegopereira/Local Sites/compsupp-7554/app/public/wp-content/plugins/debug-bar-localization/class-debug-bar-localization.php on line 463
```